### PR TITLE
Fixes actor checking in checkPermission API.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -361,20 +361,21 @@ api.checkPermission = function(tableOrActor, permission, options, callback) {
     options = {};
   }
 
-  if(tableOrActor !== null && typeof tableOrActor !== 'object') {
-    throw new TypeError('tableOrActor must be null or an object.');
-  }
-
   // use permission ID if full permission given
   if(typeof permission === 'object') {
     permission = permission.id;
   }
 
-  if(tableOrActor === null ||
-    tableOrActor.sysResourceRole || tableOrActor.sysPermissionTable) {
-    // tableOrActor is an actor
+  if(tableOrActor === null || tableOrActor === undefined ||
+    (typeof tableOrActor === 'object' &&
+    (tableOrActor.sysResourceRole || tableOrActor.sysPermissionTable))) {
     return api.checkActorPermission(
       tableOrActor, permission, options, callback);
+  }
+
+  // tableOrActor must be a table
+  if(typeof tableOrActor !== 'object') {
+    throw new TypeError('tableOrActor must an object.');
   }
 
   // options don't matter, permission granted for all resources
@@ -541,7 +542,9 @@ api.resourceToPropertyIdentifier = function(properties) {
       // TODO: support default identifiers for properties?
       // populate resource if necessary
       if(options.get &&
+        // id is missing or more than one property: get resources OR...
         ((typeof resource === 'string' && (!hasId || properties.length > 1)) ||
+        // properties is not a subset of resource object: get resources
         (bedrock.util.isObject(resource) &&
         _.intersection(Object.keys(resource), properties).length !==
         properties.length))) {


### PR DESCRIPTION
This change will fix api.checkPermission 'actor' argument checks.   Since an actor can be 'null', the check for actor is performed before the check for a non-valid actor.

Comments will be added to api.resourceToPropertyIdentifier to clarify how the get option logic works. 

Will affect:  https://github.com/digitalbazaar/bedrock-key/pull/7
