### PR TITLE
Do pass undefined result to callback.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -305,7 +305,12 @@ api.checkPermission = function(tableOrActor, permission, options, callback) {
     callback = options;
     options = {};
   }
-  return _checkPermission(tableOrActor, permission, options, callback);
+  return _checkPermission(tableOrActor, permission, options, (err, result) => {
+    if(result === undefined) {
+      return callback(err);
+    }
+    callback(err, result);
+  });
 };
 
 /**


### PR DESCRIPTION
I came to this via bedrock-identity-http and bedrock-identity@4.  The callbackify stuff does not like arguments that === undefined.