### PR TITLE
Update to mongo 3.5 api.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mongodb:
-        image: mongo:3.6
+        image: mongo:4.2
         ports:
           - 27017:27017
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
+        mongodb-version: ['4.2']
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -47,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mongodb:
-        image: mongo:3.6
+        image: mongo:4.2
         ports:
           - 27017:27017
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
-        mongodb-version: ['4.2']
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-permission ChangeLog
 
+## 3.0.0 -
+
+### Changed
+- **BREAKING**: Upgrade `bedrock-mongodb` to ^7.0.0.
+- Change mongo APIs to conform to mongo driver 3.5.
+
 # 2.5.4 - 2019-11-12
 
 ### Changed

--- a/lib/index.js
+++ b/lib/index.js
@@ -157,7 +157,7 @@ api.addRole = brCallbackify(async (actor, role) => {
   };
 
   await _checkPermission(actor, PERMISSIONS.ROLE_CREATE);
-  const result = await database.collections.role.insert(
+  const result = await database.collections.role.insertOne(
     record, database.writeOptions);
   return result.ops[0];
 });
@@ -172,7 +172,7 @@ api.addRole = brCallbackify(async (actor, role) => {
 api.updateRole = brCallbackify(async (actor, role) => {
   // TODO: update API to use patch and sequence
   await _checkPermission(actor, PERMISSIONS.ROLE_UPDATE);
-  await database.collections.role.update(
+  await database.collections.role.updateOne(
     {id: database.hash(role.id)}, {$set: {role}}, database.writeOptions);
   return role;
 });
@@ -186,7 +186,7 @@ api.updateRole = brCallbackify(async (actor, role) => {
  */
 api.removeRole = brCallbackify(async (actor, id) => {
   await _checkPermission(actor, PERMISSIONS.ROLE_REMOVE);
-  await database.collections.role.update({
+  await database.collections.role.updateOne({
     id: database.hash(id)
   }, {
     // TODO: use `meta.status`

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lib": "./lib"
   },
   "devDependencies": {
-    "eslint": "^6.8.0",
+    "eslint": "^7.2.0",
     "eslint-config-digitalbazaar": "^2.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "bedrock": "1.12.1 - 3.x",
-    "bedrock-mongodb": "3.x - 7.x"
+    "bedrock-mongodb": "^7.0.0"
   },
   "directories": {
     "lib": "./lib"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "bedrock": "1.12.1 - 3.x",
-    "bedrock-mongodb": "3.x - 6.x"
+    "bedrock-mongodb": "3.x - 7.x"
   },
   "directories": {
     "lib": "./lib"

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -33,7 +33,7 @@ api.getActors = async mockData => {
 api.removeCollections = async (collectionNames = ['identity']) => {
   await promisify(database.openCollections)(collectionNames);
   for(const collectionName of collectionNames) {
-    await database.collections[collectionName].remove({});
+    await database.collections[collectionName].deleteMany({});
   }
 };
 

--- a/test/package.json
+++ b/test/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bedrock": "^3.0.1",
     "bedrock-identity": "digitalbazaar/bedrock-identity#mongo-version-3",
-    "bedrock-mongodb": "digitalbazaar/bedrock-mongodb#driver3",
+    "bedrock-mongodb": "^7.0.0",
     "bedrock-permission": "file:..",
     "bedrock-test": "^5.0.0",
     "bedrock-validation": "^4.2.0",

--- a/test/package.json
+++ b/test/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "bedrock": "^3.0.1",
-    "bedrock-identity": "digitalbazaar/bedrock-identity#mongo-version-3",
+    "bedrock-identity": "^8.0.0",
     "bedrock-mongodb": "^7.0.0",
     "bedrock-permission": "file:..",
     "bedrock-test": "^5.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "bedrock": "^3.0.1",
-    "bedrock-identity": "^7.0.0",
-    "bedrock-mongodb": "^6.0.2",
+    "bedrock-identity": "digitalbazaar/bedrock-identity#mongo-version-3",
+    "bedrock-mongodb": "digitalbazaar/bedrock-mongodb#driver3",
     "bedrock-permission": "file:..",
     "bedrock-test": "^5.0.0",
     "bedrock-validation": "^4.2.0",


### PR DESCRIPTION
This is a major release (uses the newer mongo api).
NOTE: this does need the next release of `bedrock-identity` in `/test/` deps.

Tests will fail until `bedrock-identity: ^8.0.0` is released.

once both permission and identity are released this PR is next:

https://github.com/digitalbazaar/bedrock-account/pull/14